### PR TITLE
Modify some traits to manual implementation

### DIFF
--- a/src/bounded_impls/cmp.rs
+++ b/src/bounded_impls/cmp.rs
@@ -3,6 +3,13 @@
 use crate::{expr::AsBound, Bounded};
 use std::cmp::Ordering;
 
+impl<T, B> Eq for Bounded<T, B>
+where
+    Self: PartialEq<Self>,
+    B: AsBound<T>,
+{
+}
+
 /// Bounded to Bounded PartialEq
 impl<OT, OB, ST, SB> PartialEq<Bounded<OT, OB>> for Bounded<ST, SB>
 where
@@ -13,6 +20,16 @@ where
     #[inline]
     fn eq(&self, other: &Bounded<OT, OB>) -> bool {
         self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl<T, B> Ord for Bounded<T, B>
+where
+    T: Ord,
+    B: AsBound<T>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_ref().cmp(other.as_ref())
     }
 }
 

--- a/src/bounded_impls/misc.rs
+++ b/src/bounded_impls/misc.rs
@@ -3,7 +3,7 @@ use crate::{
     value::ToValue,
     Bounded,
 };
-use std::marker::PhantomData;
+use std::{hash::Hash, marker::PhantomData};
 use typenum::{U0, Z0};
 
 pub trait DefaultValueType: std::marker::Sized {
@@ -69,5 +69,15 @@ where
             value: T::default(),
             bound: PhantomData,
         }
+    }
+}
+
+impl<T, B> Hash for Bounded<T, B>
+where
+    B: AsBound<T>,
+    T: Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 use value::ToValue;
 
 /// A wrapper struct representing bounded numeric type.
-#[derive(Shrinkwrap, Copy, Clone, Debug, Hash, Eq, Ord)]
+#[derive(Shrinkwrap, Copy, Clone, Debug)]
 pub struct Bounded<T, B: AsBound<T>> {
     #[shrinkwrap(main_field)]
     value: T,


### PR DESCRIPTION
Implement `Eq`, `Ord` and `Hash` manually to avoid PhantomData.